### PR TITLE
Chore e2e Playwright tests

### DIFF
--- a/.github/actions/post-be-test-results/action.yml
+++ b/.github/actions/post-be-test-results/action.yml
@@ -35,18 +35,11 @@ runs:
           const beUnitSummary = parsePytestSummary(unitOutput);
           const beIntegrationSummary = parsePytestSummary(integrationOutput);
 
-          // Resolve BE artifact URLs
-          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: context.runId,
-          });
-          const artifactUrl = (name) => {
-            const a = artifacts.data.artifacts.find(x => x.name === name);
-            return a ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${a.id}` : null;
-          };
-          const beUnitAllureUrl = artifactUrl('be-unit-allure-report');
-          const beIntegrationAllureUrl = artifactUrl('be-integration-allure-report');
+          // Construct GitHub Pages report URLs
+          const pagesBase = `https://${context.repo.owner.toLowerCase()}.github.io/${context.repo.repo}`;
+          const reportsBase = `${pagesBase}/reports/${context.runId}`;
+          const beUnitAllureUrl = `${reportsBase}/be-unit`;
+          const beIntegrationAllureUrl = `${reportsBase}/be-integration`;
 
           // Find existing comment
           const comments = await github.rest.issues.listComments({

--- a/.github/actions/post-be-test-results/action.yml
+++ b/.github/actions/post-be-test-results/action.yml
@@ -79,10 +79,11 @@ runs:
 
           // Build BE reports block (owns BE allure links)
           const beReportLinks = [
-            beUnitAllureUrl && `- [📊 BE Unit Allure Report](${beUnitAllureUrl})`,
-            beIntegrationAllureUrl && `- [📊 BE Integration Allure Report](${beIntegrationAllureUrl})`,
+            beUnitAllureUrl && `- [📊 Unit Tests Allure Report](${beUnitAllureUrl})`,
+            beIntegrationAllureUrl && `- [📊 Integration Tests Allure Report](${beIntegrationAllureUrl})`,
           ].filter(Boolean).join('\n          ');
           const beReportsBlock = `<!-- be-reports -->
+          **BE Reports**
           ${beReportLinks || '_No BE reports available yet_'}
           <!-- /be-reports -->`;
 

--- a/.github/actions/post-be-test-results/action.yml
+++ b/.github/actions/post-be-test-results/action.yml
@@ -79,8 +79,8 @@ runs:
 
           // Build BE reports block (owns BE allure links)
           const beReportLinks = [
-            beUnitAllureUrl && `- [📊 Unit Tests Allure Report](${beUnitAllureUrl})`,
-            beIntegrationAllureUrl && `- [📊 Integration Tests Allure Report](${beIntegrationAllureUrl})`,
+            beUnitAllureUrl && `• [📊 Unit Tests Allure Report](${beUnitAllureUrl})`,
+            beIntegrationAllureUrl && `• [📊 Integration Tests Allure Report](${beIntegrationAllureUrl})`,
           ].filter(Boolean).join('\n          ');
           const beReportsBlock = `<!-- be-reports -->
           **BE Reports**

--- a/.github/actions/post-be-test-results/action.yml
+++ b/.github/actions/post-be-test-results/action.yml
@@ -35,6 +35,19 @@ runs:
           const beUnitSummary = parsePytestSummary(unitOutput);
           const beIntegrationSummary = parsePytestSummary(integrationOutput);
 
+          // Resolve BE artifact URLs
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          });
+          const artifactUrl = (name) => {
+            const a = artifacts.data.artifacts.find(x => x.name === name);
+            return a ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${a.id}` : null;
+          };
+          const beUnitAllureUrl = artifactUrl('be-unit-allure-report');
+          const beIntegrationAllureUrl = artifactUrl('be-integration-allure-report');
+
           // Find existing comment
           const comments = await github.rest.issues.listComments({
             issue_number: context.issue.number,
@@ -64,17 +77,38 @@ runs:
           ${beIntegrationSummary}
           \`\`\``;
 
+          // Build BE reports block (owns BE allure links)
+          const beReportLinks = [
+            beUnitAllureUrl && `- [📊 BE Unit Allure Report](${beUnitAllureUrl})`,
+            beIntegrationAllureUrl && `- [📊 BE Integration Allure Report](${beIntegrationAllureUrl})`,
+          ].filter(Boolean).join('\n          ');
+          const beReportsBlock = `<!-- be-reports -->
+          ${beReportLinks || '_No BE reports available yet_'}
+          <!-- /be-reports -->`;
+
           if (existingComment) {
-            // Extract FE results if they exist
+            // Extract FE results section (stop before BE or end)
             const feMatch = existingComment.body.match(/(### FE Test Results[\s\S]*?)(?=### BE|$)/);
             const feSection = feMatch ? feMatch[1].trim() : '### FE Test Results\n_Waiting for frontend tests to complete..._';
+
+            // Preserve FE reports block if already posted by FE workflow
+            const feReportsMatch = existingComment.body.match(/<!-- fe-reports -->([\s\S]*?)<!-- \/fe-reports -->/);
+            const feReportsBlock = feReportsMatch
+              ? `<!-- fe-reports -->${feReportsMatch[1]}<!-- /fe-reports -->`
+              : `<!-- fe-reports -->\n          _FE reports not available yet_\n          <!-- /fe-reports -->`;
+
+            const reportsSection = `### Test Reports
+          ${feReportsBlock}
+          ${beReportsBlock}`;
 
             const body = `<!-- test-results-summary -->
             ## Test Results Summary
 
             ${feSection}
 
-            ${beBody}`;
+            ${beBody}
+
+            ${reportsSection}`;
 
             await github.rest.issues.updateComment({
               comment_id: existingComment.id,
@@ -83,6 +117,12 @@ runs:
               body: body
             });
           } else {
+            const reportsSection = `### Test Reports
+          <!-- fe-reports -->
+          _FE reports not available yet_
+          <!-- /fe-reports -->
+          ${beReportsBlock}`;
+
             // Create new comment with placeholder for FE results
             const body = `<!-- test-results-summary -->
             ## Test Results Summary
@@ -90,7 +130,9 @@ runs:
             ### FE Test Results
             _Frontend tests were not executed or still running..._
 
-            ${beBody}`;
+            ${beBody}
+
+            ${reportsSection}`;
 
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -53,16 +53,19 @@ runs:
           const feIntegrationSummary = parseSummary(integrationOutput);
           const feE2eSummary = parsePlaywrightSummary(e2eOutput);
 
-          // Resolve Playwright report artifact URL
+          // Resolve FE artifact URLs
           const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: context.runId,
           });
-          const playwrightArtifact = artifacts.data.artifacts.find(a => a.name === 'playwright-report');
-          const playwrightReportUrl = playwrightArtifact
-            ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${playwrightArtifact.id}`
-            : null;
+          const artifactUrl = (name) => {
+            const a = artifacts.data.artifacts.find(x => x.name === name);
+            return a ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${a.id}` : null;
+          };
+          const playwrightReportUrl = artifactUrl('playwright-report');
+          const feUnitAllureUrl = artifactUrl('fe-unit-allure-report');
+          const feIntegrationAllureUrl = artifactUrl('fe-integration-allure-report');
 
           // Find existing comment or create placeholder
           const comments = await github.rest.issues.listComments({
@@ -100,13 +103,30 @@ runs:
           ${feE2eSummary}
           \`\`\``;
 
-          const reportsSection = `### Test Reports
-          ${playwrightReportUrl ? `- [📊 Playwright Report](${playwrightReportUrl})` : '_No reports available_'}`;
+          // Build FE reports block (owns playwright + FE allure links)
+          const feReportLinks = [
+            playwrightReportUrl && `- [🎭 Playwright Report](${playwrightReportUrl})`,
+            feUnitAllureUrl && `- [📊 FE Unit Allure Report](${feUnitAllureUrl})`,
+            feIntegrationAllureUrl && `- [📊 FE Integration Allure Report](${feIntegrationAllureUrl})`,
+          ].filter(Boolean).join('\n          ');
+          const feReportsBlock = `<!-- fe-reports -->
+          ${feReportLinks || '_No FE reports available yet_'}
+          <!-- /fe-reports -->`;
 
           if (existingComment) {
-            // Extract BE results if they exist in the comment
-            const beMatch = existingComment.body.match(/(### BE Test Results[\s\S]*?)(?=### Test Reports|### FE|$)/);
+            // Extract BE results section (stop before Test Reports or end)
+            const beMatch = existingComment.body.match(/(### BE Test Results[\s\S]*?)(?=### Test Reports|$)/);
             const beSection = beMatch ? beMatch[1].trim() : '';
+
+            // Preserve BE reports block if already posted by BE workflow
+            const beReportsMatch = existingComment.body.match(/<!-- be-reports -->([\s\S]*?)<!-- \/be-reports -->/);
+            const beReportsBlock = beReportsMatch
+              ? `<!-- be-reports -->${beReportsMatch[1]}<!-- /be-reports -->`
+              : `<!-- be-reports -->\n          _BE reports not available yet_\n          <!-- /be-reports -->`;
+
+            const reportsSection = `### Test Reports
+          ${feReportsBlock}
+          ${beReportsBlock}`;
 
             const body = `<!-- test-results-summary -->
             ## Test Results Summary
@@ -124,6 +144,12 @@ runs:
               body: body
             });
           } else {
+            const reportsSection = `### Test Reports
+          ${feReportsBlock}
+          <!-- be-reports -->
+          _BE reports not available yet_
+          <!-- /be-reports -->`;
+
             // Create new comment with placeholder for BE results
             const body = `<!-- test-results-summary -->
             ## Test Results Summary

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -53,19 +53,12 @@ runs:
           const feIntegrationSummary = parseSummary(integrationOutput);
           const feE2eSummary = parsePlaywrightSummary(e2eOutput);
 
-          // Resolve FE artifact URLs
-          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            run_id: context.runId,
-          });
-          const artifactUrl = (name) => {
-            const a = artifacts.data.artifacts.find(x => x.name === name);
-            return a ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${a.id}` : null;
-          };
-          const playwrightReportUrl = artifactUrl('playwright-report');
-          const feUnitAllureUrl = artifactUrl('fe-unit-allure-report');
-          const feIntegrationAllureUrl = artifactUrl('fe-integration-allure-report');
+          // Construct GitHub Pages report URLs
+          const pagesBase = `https://${context.repo.owner.toLowerCase()}.github.io/${context.repo.repo}`;
+          const reportsBase = `${pagesBase}/reports/${context.runId}`;
+          const playwrightReportUrl = `${reportsBase}/playwright`;
+          const feUnitAllureUrl = `${reportsBase}/fe-unit`;
+          const feIntegrationAllureUrl = `${reportsBase}/fe-integration`;
 
           // Find existing comment or create placeholder
           const comments = await github.rest.issues.listComments({

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -105,9 +105,9 @@ runs:
 
           // Build FE reports block (owns playwright + FE allure links)
           const feReportLinks = [
-            feUnitAllureUrl && `- [📊 Unit Tests Allure Report](${feUnitAllureUrl})`,
-            feIntegrationAllureUrl && `- [📊 Integration Tests Allure Report](${feIntegrationAllureUrl})`,
-            playwrightReportUrl && `- [🎭 E2E Tests Playwright Report](${playwrightReportUrl})`,
+            feUnitAllureUrl && `• [📊 Unit Tests Allure Report](${feUnitAllureUrl})`,
+            feIntegrationAllureUrl && `• [📊 Integration Tests Allure Report](${feIntegrationAllureUrl})`,
+            playwrightReportUrl && `• [🎭 E2E Tests Playwright Report](${playwrightReportUrl})`,
           ].filter(Boolean).join('\n          ');
           const feReportsBlock = `<!-- fe-reports -->
           **FE Reports**

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -105,11 +105,12 @@ runs:
 
           // Build FE reports block (owns playwright + FE allure links)
           const feReportLinks = [
-            playwrightReportUrl && `- [🎭 Playwright Report](${playwrightReportUrl})`,
-            feUnitAllureUrl && `- [📊 FE Unit Allure Report](${feUnitAllureUrl})`,
-            feIntegrationAllureUrl && `- [📊 FE Integration Allure Report](${feIntegrationAllureUrl})`,
+            feUnitAllureUrl && `- [📊 Unit Tests Allure Report](${feUnitAllureUrl})`,
+            feIntegrationAllureUrl && `- [📊 Integration Tests Allure Report](${feIntegrationAllureUrl})`,
+            playwrightReportUrl && `- [🎭 E2E Tests Playwright Report](${playwrightReportUrl})`,
           ].filter(Boolean).join('\n          ');
           const feReportsBlock = `<!-- fe-reports -->
+          **FE Reports**
           ${feReportLinks || '_No FE reports available yet_'}
           <!-- /fe-reports -->`;
 

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -53,6 +53,17 @@ runs:
           const feIntegrationSummary = parseSummary(integrationOutput);
           const feE2eSummary = parsePlaywrightSummary(e2eOutput);
 
+          // Resolve Playwright report artifact URL
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+          });
+          const playwrightArtifact = artifacts.data.artifacts.find(a => a.name === 'playwright-report');
+          const playwrightReportUrl = playwrightArtifact
+            ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${playwrightArtifact.id}`
+            : null;
+
           // Find existing comment or create placeholder
           const comments = await github.rest.issues.listComments({
             issue_number: context.issue.number,
@@ -89,9 +100,12 @@ runs:
           ${feE2eSummary}
           \`\`\``;
 
+          const reportsSection = `### Test Reports
+          ${playwrightReportUrl ? `- [📊 Playwright Report](${playwrightReportUrl})` : '_No reports available_'}`;
+
           if (existingComment) {
             // Extract BE results if they exist in the comment
-            const beMatch = existingComment.body.match(/(### BE Test Results[\s\S]*?)(?=### FE|$)/);
+            const beMatch = existingComment.body.match(/(### BE Test Results[\s\S]*?)(?=### Test Reports|### FE|$)/);
             const beSection = beMatch ? beMatch[1].trim() : '';
 
             const body = `<!-- test-results-summary -->
@@ -99,7 +113,9 @@ runs:
 
             ${feBody}
 
-            ${beSection}`;
+            ${beSection}
+
+            ${reportsSection}`;
 
             await github.rest.issues.updateComment({
               comment_id: existingComment.id,
@@ -115,7 +131,9 @@ runs:
             ${feBody}
 
             ### BE Test Results
-            _Backend tests were not executed or still running..._`;
+            _Backend tests were not executed or still running..._
+
+            ${reportsSection}`;
 
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/actions/post-fe-test-results/action.yml
+++ b/.github/actions/post-fe-test-results/action.yml
@@ -22,9 +22,11 @@ runs:
           // Read FE test outputs
           const unitFile = findTestFile('unit-test-output');
           const integrationFile = findTestFile('integration-test-output');
+          const e2eFile = findTestFile('e2e-test-output');
 
           const unitOutput = unitFile ? fs.readFileSync(unitFile, 'utf8') : '';
           const integrationOutput = integrationFile ? fs.readFileSync(integrationFile, 'utf8') : '';
+          const e2eOutput = e2eFile ? fs.readFileSync(e2eFile, 'utf8') : '';
 
           // Parse Jest summary
           const parseSummary = (output) => {
@@ -38,8 +40,18 @@ runs:
             ).join('\n') || 'No results available';
           };
 
+          // Parse Playwright summary
+          const parsePlaywrightSummary = (output) => {
+            const lines = output.split('\n');
+            return lines.filter(line =>
+              /\d+\s+(passed|failed|skipped)/.test(line) ||
+              /Running \d+ test/.test(line)
+            ).join('\n') || 'No results available';
+          };
+
           const feUnitSummary = parseSummary(unitOutput);
           const feIntegrationSummary = parseSummary(integrationOutput);
+          const feE2eSummary = parsePlaywrightSummary(e2eOutput);
 
           // Find existing comment or create placeholder
           const comments = await github.rest.issues.listComments({
@@ -55,9 +67,11 @@ runs:
           // Detect test failures by looking for "failed" in the summary line
           const hasUnitFailure = unitOutput.match(/^\s*Tests:\s+.*\d+\s+failed/m);
           const hasIntegrationFailure = integrationOutput.match(/^\s*Tests:\s+.*\d+\s+failed/m);
+          const hasE2eFailure = e2eOutput.match(/\d+\s+failed/);
 
           const unitIcon = hasUnitFailure ? '❌' : '✅';
           const integrationIcon = hasIntegrationFailure ? '❌' : '✅';
+          const e2eIcon = hasE2eFailure ? '❌' : '✅';
 
           let feBody = `### FE Test Results
           **Unit Tests** ${unitIcon}
@@ -68,6 +82,11 @@ runs:
           **Integration Tests** ${integrationIcon}
           \`\`\`
           ${feIntegrationSummary}
+          \`\`\`
+
+          **E2E Tests** ${e2eIcon}
+          \`\`\`
+          ${feE2eSummary}
           \`\`\``;
 
           if (existingComment) {

--- a/.github/workflows/_test_backend.yaml
+++ b/.github/workflows/_test_backend.yaml
@@ -176,6 +176,7 @@ jobs:
     if: always()
     permissions:
       pull-requests: write
+      contents: write
 
     steps:
       - name: 📁 Checkout code
@@ -183,6 +184,22 @@ jobs:
 
       - name: 📥 Download test outputs
         uses: actions/download-artifact@v4
+
+      - name: 📦 Prepare reports directory
+        if: "!cancelled()"
+        run: |
+          mkdir -p be-reports/be-unit be-reports/be-integration
+          [ -d be-unit-allure-report ]        && cp -r be-unit-allure-report/.        be-reports/be-unit/        || true
+          [ -d be-integration-allure-report ] && cp -r be-integration-allure-report/. be-reports/be-integration/ || true
+
+      - name: 🚀 Deploy BE reports to GitHub Pages
+        if: "!cancelled()"
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./be-reports
+          destination_dir: reports/${{ github.run_id }}
+          keep_files: true
 
       - name: 📤 Post BE test results
         uses: ./.github/actions/post-be-test-results

--- a/.github/workflows/_test_backend.yaml
+++ b/.github/workflows/_test_backend.yaml
@@ -55,7 +55,18 @@ jobs:
       - name: 🧪 Run tests
         run: |
           set -o pipefail
-          pytest tests/unit  -v 2>&1 | tee unit-test-output.txt
+          pytest tests/unit -v --alluredir=allure-results 2>&1 | tee unit-test-output.txt
+
+      - name: 🔧 Setup Allure CLI
+        if: "!cancelled()"
+        run: |
+          curl -sLo /tmp/allure.tgz https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
+          tar -xzf /tmp/allure.tgz -C /tmp
+          echo "/tmp/allure-2.27.0/bin" >> $GITHUB_PATH
+
+      - name: 📊 Generate Allure report
+        if: "!cancelled()"
+        run: allure generate allure-results -o allure-report --clean
 
       - name: 📤 Upload unit test output
         if: "!cancelled()"
@@ -64,6 +75,14 @@ jobs:
           name: be-unit-test-output
           path: backend/unit-test-output.txt
           retention-days: 1
+
+      - name: 📤 Upload unit Allure report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: be-unit-allure-report
+          path: backend/allure-report/
+          retention-days: 7
 
   integration_tests:
     name: ⚙️ Run integration tests
@@ -121,7 +140,18 @@ jobs:
       - name: 🧪 Run tests
         run: |
           set -o pipefail
-          pytest tests/integration -v 2>&1 | tee integration-test-output.txt
+          pytest tests/integration -v --alluredir=allure-results 2>&1 | tee integration-test-output.txt
+
+      - name: 🔧 Setup Allure CLI
+        if: "!cancelled()"
+        run: |
+          curl -sLo /tmp/allure.tgz https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
+          tar -xzf /tmp/allure.tgz -C /tmp
+          echo "/tmp/allure-2.27.0/bin" >> $GITHUB_PATH
+
+      - name: 📊 Generate Allure report
+        if: "!cancelled()"
+        run: allure generate allure-results -o allure-report --clean
 
       - name: 📤 Upload integration test output
         if: "!cancelled()"
@@ -130,6 +160,14 @@ jobs:
           name: be-integration-test-output
           path: backend/integration-test-output.txt
           retention-days: 1
+
+      - name: 📤 Upload integration Allure report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: be-integration-allure-report
+          path: backend/allure-report/
+          retention-days: 7
 
   report_results:
     name: 💬 Post test results

--- a/.github/workflows/_test_backend.yaml
+++ b/.github/workflows/_test_backend.yaml
@@ -57,6 +57,24 @@ jobs:
           set -o pipefail
           pytest tests/unit -v --alluredir=allure-results 2>&1 | tee unit-test-output.txt
 
+      - name: 📚 Fetch Allure history
+        if: "!cancelled()"
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-history
+          sparse-checkout: history/be-unit
+          sparse-checkout-cone-mode: false
+
+      - name: 📁 Restore Allure history
+        if: "!cancelled()"
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p backend/allure-results/history
+          [ -d gh-pages-history/history/be-unit ] && \
+            cp -r gh-pages-history/history/be-unit/. backend/allure-results/history/ || true
+
       - name: 🔧 Setup Allure CLI
         if: "!cancelled()"
         run: |
@@ -142,6 +160,24 @@ jobs:
           set -o pipefail
           pytest tests/integration -v --alluredir=allure-results 2>&1 | tee integration-test-output.txt
 
+      - name: 📚 Fetch Allure history
+        if: "!cancelled()"
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-history
+          sparse-checkout: history/be-integration
+          sparse-checkout-cone-mode: false
+
+      - name: 📁 Restore Allure history
+        if: "!cancelled()"
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p backend/allure-results/history
+          [ -d gh-pages-history/history/be-integration ] && \
+            cp -r gh-pages-history/history/be-integration/. backend/allure-results/history/ || true
+
       - name: 🔧 Setup Allure CLI
         if: "!cancelled()"
         run: |
@@ -185,20 +221,24 @@ jobs:
       - name: 📥 Download test outputs
         uses: actions/download-artifact@v4
 
-      - name: 📦 Prepare reports directory
+      - name: 📦 Prepare reports and history directories
         if: "!cancelled()"
         run: |
-          mkdir -p be-reports/be-unit be-reports/be-integration
-          [ -d be-unit-allure-report ]        && cp -r be-unit-allure-report/.        be-reports/be-unit/        || true
-          [ -d be-integration-allure-report ] && cp -r be-integration-allure-report/. be-reports/be-integration/ || true
+          mkdir -p deploy/reports/${{ github.run_id }}/be-unit
+          mkdir -p deploy/reports/${{ github.run_id }}/be-integration
+          mkdir -p deploy/history/be-unit
+          mkdir -p deploy/history/be-integration
+          [ -d be-unit-allure-report ]        && cp -r be-unit-allure-report/.        deploy/reports/${{ github.run_id }}/be-unit/        || true
+          [ -d be-integration-allure-report ] && cp -r be-integration-allure-report/. deploy/reports/${{ github.run_id }}/be-integration/ || true
+          [ -d be-unit-allure-report/history ]        && cp -r be-unit-allure-report/history/.        deploy/history/be-unit/        || true
+          [ -d be-integration-allure-report/history ] && cp -r be-integration-allure-report/history/. deploy/history/be-integration/ || true
 
       - name: 🚀 Deploy BE reports to GitHub Pages
         if: "!cancelled()"
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./be-reports
-          destination_dir: reports/${{ github.run_id }}
+          publish_dir: ./deploy
           keep_files: true
 
       - name: 📤 Post BE test results

--- a/.github/workflows/_test_frontend.yaml
+++ b/.github/workflows/_test_frontend.yaml
@@ -57,9 +57,20 @@ jobs:
       - name: 🧪 Run unit tests
         run: |
           set -o pipefail
-          npm test -- --coverage --watchAll=false --testTimeout=10000 2>&1 | tee unit-test-output.txt
+          npm test -- --coverage --watchAll=false --testTimeout=10000 --reporters=default --reporters=allure-jest 2>&1 | tee unit-test-output.txt
         env:
           CI: true
+
+      - name: 🔧 Setup Allure CLI
+        if: "!cancelled()"
+        run: |
+          curl -sLo /tmp/allure.tgz https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
+          tar -xzf /tmp/allure.tgz -C /tmp
+          echo "/tmp/allure-2.27.0/bin" >> $GITHUB_PATH
+
+      - name: 📊 Generate Allure report
+        if: "!cancelled()"
+        run: allure generate allure-results -o allure-report --clean
 
       - name: 📤 Upload unit test output
         if: "!cancelled()"
@@ -68,6 +79,14 @@ jobs:
           name: unit-test-output
           path: frontend/unit-test-output.txt
           retention-days: 1
+
+      - name: 📤 Upload unit Allure report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: fe-unit-allure-report
+          path: frontend/allure-report/
+          retention-days: 7
 
   integration_tests:
     name: ⚙️ Run integration tests
@@ -121,7 +140,7 @@ jobs:
         run: |
           set -o pipefail
           # Run a focused subset of tests that verify app integration with running server
-          npm test -- --testPathPattern="(services|hooks)" --watchAll=false --testTimeout=10000 2>&1 | tee integration-test-output.txt
+          npm test -- --testPathPattern="(services|hooks)" --watchAll=false --testTimeout=10000 --reporters=default --reporters=allure-jest 2>&1 | tee integration-test-output.txt
         env:
           CI: true
           REACT_APP_API_URL: http://localhost:3000
@@ -134,6 +153,17 @@ jobs:
             rm app.pid
           fi
 
+      - name: 🔧 Setup Allure CLI
+        if: "!cancelled()"
+        run: |
+          curl -sLo /tmp/allure.tgz https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
+          tar -xzf /tmp/allure.tgz -C /tmp
+          echo "/tmp/allure-2.27.0/bin" >> $GITHUB_PATH
+
+      - name: 📊 Generate Allure report
+        if: "!cancelled()"
+        run: allure generate allure-results -o allure-report --clean
+
       - name: 📤 Upload integration test output
         if: "!cancelled()"
         uses: actions/upload-artifact@v4
@@ -141,6 +171,14 @@ jobs:
           name: integration-test-output
           path: frontend/integration-test-output.txt
           retention-days: 1
+
+      - name: 📤 Upload integration Allure report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: fe-integration-allure-report
+          path: frontend/allure-report/
+          retention-days: 7
 
   e2e_tests:
     name: 🎭 Run Playwright e2e tests

--- a/.github/workflows/_test_frontend.yaml
+++ b/.github/workflows/_test_frontend.yaml
@@ -57,9 +57,11 @@ jobs:
       - name: 🧪 Run unit tests
         run: |
           set -o pipefail
-          npm test -- --coverage --watchAll=false --testTimeout=10000 --reporters=default --reporters=allure-jest 2>&1 | tee unit-test-output.txt
+          npm test -- --coverage --watchAll=false --testTimeout=10000 --reporters=default --reporters=jest-junit 2>&1 | tee unit-test-output.txt
         env:
           CI: true
+          JEST_JUNIT_OUTPUT_DIR: allure-results
+          JEST_JUNIT_OUTPUT_NAME: junit.xml
 
       - name: 🔧 Setup Allure CLI
         if: "!cancelled()"
@@ -140,10 +142,12 @@ jobs:
         run: |
           set -o pipefail
           # Run a focused subset of tests that verify app integration with running server
-          npm test -- --testPathPattern="(services|hooks)" --watchAll=false --testTimeout=10000 --reporters=default --reporters=allure-jest 2>&1 | tee integration-test-output.txt
+          npm test -- --testPathPattern="(services|hooks)" --watchAll=false --testTimeout=10000 --reporters=default --reporters=jest-junit 2>&1 | tee integration-test-output.txt
         env:
           CI: true
           REACT_APP_API_URL: http://localhost:3000
+          JEST_JUNIT_OUTPUT_DIR: allure-results
+          JEST_JUNIT_OUTPUT_NAME: junit.xml
 
       - name: 🛑 Stop React application
         if: always()

--- a/.github/workflows/_test_frontend.yaml
+++ b/.github/workflows/_test_frontend.yaml
@@ -142,10 +142,58 @@ jobs:
           path: frontend/integration-test-output.txt
           retention-days: 1
 
+  e2e_tests:
+    name: 🎭 Run Playwright e2e tests
+    runs-on: ubuntu-latest
+    needs: lint
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: 📁 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: "./frontend/package-lock.json"
+
+      - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 🎭 Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: 🎭 Run Playwright e2e tests
+        run: |
+          set -o pipefail
+          npm run test:e2e 2>&1 | tee e2e-test-output.txt
+        env:
+          CI: true
+
+      - name: 📤 Upload Playwright report
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: 📤 Upload e2e test output
+        if: "!cancelled()"
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-output
+          path: frontend/e2e-test-output.txt
+          retention-days: 1
+
   report_results:
     name: 💬 Post test results
     runs-on: ubuntu-latest
-    needs: [unit_tests, integration_tests]
+    needs: [unit_tests, integration_tests, e2e_tests]
     if: always()
     permissions:
       pull-requests: write

--- a/.github/workflows/_test_frontend.yaml
+++ b/.github/workflows/_test_frontend.yaml
@@ -63,6 +63,24 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: allure-results
           JEST_JUNIT_OUTPUT_NAME: junit.xml
 
+      - name: 📚 Fetch Allure history
+        if: "!cancelled()"
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-history
+          sparse-checkout: history/fe-unit
+          sparse-checkout-cone-mode: false
+
+      - name: 📁 Restore Allure history
+        if: "!cancelled()"
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p frontend/allure-results/history
+          [ -d gh-pages-history/history/fe-unit ] && \
+            cp -r gh-pages-history/history/fe-unit/. frontend/allure-results/history/ || true
+
       - name: 🔧 Setup Allure CLI
         if: "!cancelled()"
         run: |
@@ -157,6 +175,24 @@ jobs:
             rm app.pid
           fi
 
+      - name: 📚 Fetch Allure history
+        if: "!cancelled()"
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-history
+          sparse-checkout: history/fe-integration
+          sparse-checkout-cone-mode: false
+
+      - name: 📁 Restore Allure history
+        if: "!cancelled()"
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p frontend/allure-results/history
+          [ -d gh-pages-history/history/fe-integration ] && \
+            cp -r gh-pages-history/history/fe-integration/. frontend/allure-results/history/ || true
+
       - name: 🔧 Setup Allure CLI
         if: "!cancelled()"
         run: |
@@ -248,21 +284,26 @@ jobs:
       - name: 📥 Download test outputs
         uses: actions/download-artifact@v4
 
-      - name: 📦 Prepare reports directory
+      - name: 📦 Prepare reports and history directories
         if: "!cancelled()"
         run: |
-          mkdir -p fe-reports/fe-unit fe-reports/fe-integration fe-reports/playwright
-          [ -d fe-unit-allure-report ]       && cp -r fe-unit-allure-report/.       fe-reports/fe-unit/       || true
-          [ -d fe-integration-allure-report ] && cp -r fe-integration-allure-report/. fe-reports/fe-integration/ || true
-          [ -d playwright-report ]            && cp -r playwright-report/.            fe-reports/playwright/     || true
+          mkdir -p deploy/reports/${{ github.run_id }}/fe-unit
+          mkdir -p deploy/reports/${{ github.run_id }}/fe-integration
+          mkdir -p deploy/reports/${{ github.run_id }}/playwright
+          mkdir -p deploy/history/fe-unit
+          mkdir -p deploy/history/fe-integration
+          [ -d fe-unit-allure-report ]        && cp -r fe-unit-allure-report/.        deploy/reports/${{ github.run_id }}/fe-unit/        || true
+          [ -d fe-integration-allure-report ] && cp -r fe-integration-allure-report/. deploy/reports/${{ github.run_id }}/fe-integration/ || true
+          [ -d playwright-report ]            && cp -r playwright-report/.            deploy/reports/${{ github.run_id }}/playwright/     || true
+          [ -d fe-unit-allure-report/history ]        && cp -r fe-unit-allure-report/history/.        deploy/history/fe-unit/        || true
+          [ -d fe-integration-allure-report/history ] && cp -r fe-integration-allure-report/history/. deploy/history/fe-integration/ || true
 
       - name: 🚀 Deploy FE reports to GitHub Pages
         if: "!cancelled()"
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./fe-reports
-          destination_dir: reports/${{ github.run_id }}
+          publish_dir: ./deploy
           keep_files: true
 
       - name: 📤 Post FE test results

--- a/.github/workflows/_test_frontend.yaml
+++ b/.github/workflows/_test_frontend.yaml
@@ -239,6 +239,7 @@ jobs:
     if: always()
     permissions:
       pull-requests: write
+      contents: write
 
     steps:
       - name: 📁 Checkout code
@@ -246,6 +247,23 @@ jobs:
 
       - name: 📥 Download test outputs
         uses: actions/download-artifact@v4
+
+      - name: 📦 Prepare reports directory
+        if: "!cancelled()"
+        run: |
+          mkdir -p fe-reports/fe-unit fe-reports/fe-integration fe-reports/playwright
+          [ -d fe-unit-allure-report ]       && cp -r fe-unit-allure-report/.       fe-reports/fe-unit/       || true
+          [ -d fe-integration-allure-report ] && cp -r fe-integration-allure-report/. fe-reports/fe-integration/ || true
+          [ -d playwright-report ]            && cp -r playwright-report/.            fe-reports/playwright/     || true
+
+      - name: 🚀 Deploy FE reports to GitHub Pages
+        if: "!cancelled()"
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./fe-reports
+          destination_dir: reports/${{ github.run_id }}
+          keep_files: true
 
       - name: 📤 Post FE test results
         uses: ./.github/actions/post-fe-test-results

--- a/.github/workflows/mergeable.yaml
+++ b/.github/workflows/mergeable.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   check_changes:

--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,9 @@ logs/
 frontend/playwright-report
 frontend/test-results
 
+# Allure
+frontend/allure-results
+frontend/allure-report
+backend/allure-results
+backend/allure-report
+

--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,7 @@ Thumbs.db
 # Log files
 logs/
 
+# Playwright
+frontend/playwright-report
+frontend/test-results
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude
+*/settings.local.json
+
 # Python
 __pycache__/
 *.py[cod]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ httpx==0.25.2
 psycopg2-binary==2.9.10
 python-dotenv==1.0.0
 flake8==6.1.0
+allure-pytest==2.13.5

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,12 +1,6 @@
 module.exports = {
-  extends: [
-    'react-app',
-    'react-app/jest',
-    'prettier',
-  ],
-  plugins: [
-    'prettier',
-  ],
+  extends: ['react-app', 'react-app/jest', 'prettier'],
+  plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
@@ -18,6 +12,14 @@ module.exports = {
     {
       files: ['**/*.test.ts', '**/*.test.tsx'],
       rules: {
+        'no-console': 'off',
+      },
+    },
+    {
+      files: ['e2e/**/*.ts'],
+      rules: {
+        'testing-library/no-await-sync-queries': 'off',
+        'testing-library/prefer-screen-queries': 'off',
         'no-console': 'off',
       },
     },

--- a/frontend/e2e/meal-planner.spec.ts
+++ b/frontend/e2e/meal-planner.spec.ts
@@ -25,8 +25,8 @@ test.describe('Meal Planner - Add and remove a meal', () => {
     await mealPlanner.assertRecipeNotInSlot('Scrambled Eggs');
   });
 
-  test('adds a recipe to a meal slot and then removes it', async ({ page }) => {
-    await test.step('Add a breakfast recipe', async () => {
+  test('Add a breakfast for the first day of the week', async ({ page }) => {
+    await test.step('Click + to add breakfast recipe', async () => {
       await mealPlanner.openMealSlot(0);
       await mealPlanner.assertOnlyMatchingRecipes(
         'Scrambled Eggs',
@@ -40,7 +40,7 @@ test.describe('Meal Planner - Add and remove a meal', () => {
       await mealPlanner.assertSelectorClosed();
     });
 
-    await test.step('Verify recipe appears in slot', async () => {
+    await test.step('Verify recipe appears in right slot', async () => {
       await mealPlanner.assertRecipeInSlot('Scrambled Eggs');
     });
   });

--- a/frontend/e2e/meal-planner.spec.ts
+++ b/frontend/e2e/meal-planner.spec.ts
@@ -1,0 +1,47 @@
+import { test } from '@playwright/test';
+import { MealPlannerPage } from './pages/meal-planner.page';
+import {
+  MOCK_ENTRY,
+  mockAddMealPlanEntry,
+  mockDeleteMealPlanEntry,
+  mockMealPlanEntries,
+  mockRecipes,
+} from './mocks/meal-planner.mocks';
+
+test.describe('Meal Planner - Add and remove a meal', () => {
+  let mealPlanner: MealPlannerPage;
+
+  test.beforeEach(async ({ page }) => {
+    await mockRecipes(page);
+    await mockMealPlanEntries(page, []);
+
+    mealPlanner = new MealPlannerPage(page);
+    await mealPlanner.goto();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await mockDeleteMealPlanEntry(page);
+    await mealPlanner.removeRecipe('Scrambled Eggs');
+    await mealPlanner.assertRecipeNotInSlot('Scrambled Eggs');
+  });
+
+  test('adds a recipe to a meal slot and then removes it', async ({ page }) => {
+    await test.step('Add a breakfast recipe', async () => {
+      await mealPlanner.openMealSlot(0);
+      await mealPlanner.assertOnlyMatchingRecipes(
+        'Scrambled Eggs',
+        'Grilled Chicken'
+      );
+    });
+
+    await test.step('Select Scrambled Eggs', async () => {
+      await mockAddMealPlanEntry(page, MOCK_ENTRY);
+      await mealPlanner.selectRecipe(/Scrambled Eggs/i);
+      await mealPlanner.assertSelectorClosed();
+    });
+
+    await test.step('Verify recipe appears in slot', async () => {
+      await mealPlanner.assertRecipeInSlot('Scrambled Eggs');
+    });
+  });
+});

--- a/frontend/e2e/mocks/meal-planner.mocks.ts
+++ b/frontend/e2e/mocks/meal-planner.mocks.ts
@@ -1,0 +1,131 @@
+import { Page } from '@playwright/test';
+
+export interface MockRecipe {
+  id: number;
+  name: string;
+  category: string;
+  prep_time: number;
+  portions: number;
+  instructions: string;
+  main_ingredients: unknown[];
+  common_ingredients: unknown[];
+  foto_url: string | null;
+}
+
+export interface MockMealPlanEntry {
+  id: number;
+  week_start: string;
+  day_of_week: number;
+  meal_slot: string;
+  recipe_id: number;
+  recipe_name: string;
+}
+
+export const MOCK_RECIPES: MockRecipe[] = [
+  {
+    id: 1,
+    name: 'Scrambled Eggs',
+    category: 'breakfast',
+    prep_time: 10,
+    portions: 2,
+    instructions: 'Cook eggs.',
+    main_ingredients: [],
+    common_ingredients: [],
+    foto_url: null,
+  },
+  {
+    id: 2,
+    name: 'Grilled Chicken',
+    category: 'dinner',
+    prep_time: 30,
+    portions: 4,
+    instructions: 'Grill chicken.',
+    main_ingredients: [],
+    common_ingredients: [],
+    foto_url: null,
+  },
+];
+
+export const MOCK_ENTRY: MockMealPlanEntry = {
+  id: 99,
+  week_start: '2026-04-27',
+  day_of_week: 0,
+  meal_slot: 'breakfast',
+  recipe_id: 1,
+  recipe_name: 'Scrambled Eggs',
+};
+
+export async function mockRecipes(
+  page: Page,
+  recipes: MockRecipe[] = MOCK_RECIPES
+) {
+  await page.route('**/recipes', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success', recipes }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+export async function mockMealPlanEntries(
+  page: Page,
+  entries: MockMealPlanEntry[]
+) {
+  await page.route('**/meal-plans**', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success', entries }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+export async function mockAddMealPlanEntry(
+  page: Page,
+  entry: MockMealPlanEntry
+) {
+  await page.route('**/meal-plans**', async route => {
+    const method = route.request().method();
+    if (method === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(entry),
+      });
+    } else if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success', entries: [entry] }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+export async function mockDeleteMealPlanEntry(page: Page) {
+  await page.route('**/meal-plans**', async route => {
+    const method = route.request().method();
+    if (method === 'DELETE') {
+      await route.fulfill({ status: 204 });
+    } else if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'success', entries: [] }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}

--- a/frontend/e2e/pages/meal-planner.page.ts
+++ b/frontend/e2e/pages/meal-planner.page.ts
@@ -1,0 +1,70 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export class MealPlannerPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly recipeSelectorHeading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: 'Weekly Meal Plan' });
+    this.recipeSelectorHeading = page.getByRole('heading', {
+      name: /breakfast/i,
+    });
+  }
+
+  recipeOption(name: string | RegExp): Locator {
+    return this.page.getByRole('button', { name });
+  }
+
+  mealCard(recipeName: string): Locator {
+    return this.page.getByRole('button', {
+      name: new RegExp(`View ${recipeName} details`, 'i'),
+    });
+  }
+
+  removeButton(recipeName: string): Locator {
+    return this.page.getByRole('button', {
+      name: new RegExp(`Remove ${recipeName}`, 'i'),
+    });
+  }
+
+  emptyMealSlots(): Locator {
+    return this.page.locator('[role="button"]').filter({ hasText: '+' });
+  }
+
+  async goto() {
+    await this.page.goto('/meal-planner');
+    await expect(this.heading).toBeVisible();
+  }
+
+  async openMealSlot(index = 0) {
+    await this.emptyMealSlots().nth(index).click();
+    await expect(this.recipeSelectorHeading).toBeVisible();
+  }
+
+  async selectRecipe(name: string | RegExp) {
+    await this.recipeOption(name).click();
+  }
+
+  async removeRecipe(recipeName: string) {
+    await this.removeButton(recipeName).click();
+  }
+
+  async assertRecipeInSlot(recipeName: string) {
+    await expect(this.mealCard(recipeName)).toBeVisible();
+  }
+
+  async assertRecipeNotInSlot(recipeName: string) {
+    await expect(this.mealCard(recipeName)).not.toBeVisible();
+  }
+
+  async assertSelectorClosed() {
+    await expect(this.recipeSelectorHeading).not.toBeVisible();
+  }
+
+  async assertOnlyMatchingRecipes(visible: string, hidden: string) {
+    await expect(this.recipeOption(new RegExp(visible, 'i'))).toBeVisible();
+    await expect(this.recipeOption(new RegExp(hidden, 'i'))).not.toBeVisible();
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "serve": "^14.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -2996,6 +2997,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -12666,6 +12683,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14757,6 +14757,23 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/react-scripts/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^19.2.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
+        "allure-jest": "^3.0.0",
         "autoprefixer": "^10.4.24",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -4751,6 +4752,58 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/allure-jest": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/allure-jest/-/allure-jest-3.8.0.tgz",
+      "integrity": "sha512-dt2ri/xSPoUEHrV2UjihjIM+bRiDiZBC8ueTvKTQAM1j0ikTmG4STa3mvhUyzj5aOPnf/sYjDIXp7mReczX2Yw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "allure-js-commons": "3.8.0"
+      },
+      "peerDependencies": {
+        "jest": ">=24.8.0",
+        "jest-circus": ">=24.8.0",
+        "jest-cli": ">=24.8.0",
+        "jest-environment-jsdom": ">=24.8.0",
+        "jest-environment-node": ">=24.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-circus": {
+          "optional": true
+        },
+        "jest-cli": {
+          "optional": true
+        },
+        "jest-environment-jsdom": {
+          "optional": true
+        },
+        "jest-environment-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-js-commons": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.8.0.tgz",
+      "integrity": "sha512-CVPuXSKsHf6I8M1+d4JFhQ/XkaHyF/clQITPJmSXMF69seNLIDbyOlyz5nkKV4waqbb5m3wH8wMkmugy2EVkxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.8.0"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -5982,6 +6035,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -6468,6 +6531,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -9880,6 +9953,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -11815,6 +11895,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdn-data": {
@@ -14663,23 +14755,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/react-scripts/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,10 +27,10 @@
         "@types/react-dom": "^19.2.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
-        "allure-jest": "^3.0.0",
         "autoprefixer": "^10.4.24",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "jest-junit": "^16.0.0",
         "postcss": "^8.5.6",
         "prettier": "^2.8.8",
         "typescript": "^4.9.5"
@@ -4752,58 +4752,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/allure-jest": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/allure-jest/-/allure-jest-3.8.0.tgz",
-      "integrity": "sha512-dt2ri/xSPoUEHrV2UjihjIM+bRiDiZBC8ueTvKTQAM1j0ikTmG4STa3mvhUyzj5aOPnf/sYjDIXp7mReczX2Yw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "allure-js-commons": "3.8.0"
-      },
-      "peerDependencies": {
-        "jest": ">=24.8.0",
-        "jest-circus": ">=24.8.0",
-        "jest-cli": ">=24.8.0",
-        "jest-environment-jsdom": ">=24.8.0",
-        "jest-environment-node": ">=24.8.0"
-      },
-      "peerDependenciesMeta": {
-        "jest": {
-          "optional": true
-        },
-        "jest-circus": {
-          "optional": true
-        },
-        "jest-cli": {
-          "optional": true
-        },
-        "jest-environment-jsdom": {
-          "optional": true
-        },
-        "jest-environment-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/allure-js-commons": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.8.0.tgz",
-      "integrity": "sha512-CVPuXSKsHf6I8M1+d4JFhQ/XkaHyF/clQITPJmSXMF69seNLIDbyOlyz5nkKV4waqbb5m3wH8wMkmugy2EVkxw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "md5": "^2.3.0"
-      },
-      "peerDependencies": {
-        "allure-playwright": "3.8.0"
-      },
-      "peerDependenciesMeta": {
-        "allure-playwright": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -6035,16 +5983,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -6531,16 +6469,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -9953,13 +9881,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -10825,6 +10746,35 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -11895,18 +11845,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdn-data": {
@@ -18353,6 +18291,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "allure-jest": "^3.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "allure-jest": "^3.0.0",
+    "jest-junit": "^16.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,9 @@
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint src --ext .ts,.tsx,.js,.jsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "browserslist": {
     "production": [
@@ -35,6 +37,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "module": "commonjs"
+  },
+  "include": ["playwright.config.ts", "e2e/**/*.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,6 +21,8 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src"
+    "src",
+    "playwright.config.ts",
+    "e2e"
   ]
 }


### PR DESCRIPTION
# Summary

  Add Playwright e2e testing infrastructure and first test for meal planner feature.

##  Changelog
  
###  CI changes:
  - Added e2e_tests job to run Playwright tests in CI
  - Uploads Playwright report and test output artifacts
  - Made test reporting job depend on e2e tests completion

###  Frontend changes:
  - Installed Playwright test framework (@playwright/test v1.59.1)
  - Added Playwright configuration and TypeScript setup
  - Created first e2e test: meal planner add/remove recipe workflow with mocked API calls
  - Implemented Page Object pattern for meal planner test
  - Added mock utilities for recipes and meal plan entries
  - Updated ESLint rules to handle e2e test files
  - Added npm scripts test:e2e and test:e2e:ui
  - Add Allure report for unit and integration tests 
  - Add Playwright report for E2E tests 
  - Update the tests summary message 

  ### Other changes:
  - Updated .gitignore to exclude Playwright reports, test results, and Claude settings

  ---
  🤖 Generated with Claude Code